### PR TITLE
service design proposal: batched sampling

### DIFF
--- a/proto/gnpsi/gnpsi.proto
+++ b/proto/gnpsi/gnpsi.proto
@@ -30,6 +30,7 @@ service gNPSI {
   // updates from the device.  Past updates, i.e., updates before the
   // subscription is received, will not be presented to the subscribing client.
   rpc Subscribe(Request) returns (stream Sample);
+  rpc SubscribeBatch(Request) returns (stream Samples);
 }
 
 message SFlowMetadata {
@@ -85,4 +86,8 @@ message Sample {
   SFlowMetadata sflow_metadata = 101;
   NetFlowMetadata netflow_metadata = 102;
   IPFIXMetadata ipfix_metadata = 103;
+}
+
+message Samples {
+  repeated Sample samples = 1;
 }


### PR DESCRIPTION
Considering that gNPSI is expected to have relatively high messagage rate, and a low avg. message size, our team would like to propose the change that allows performing batching on the server side (instead of having to stream back each individual sample).
```
message Samples {
  repeated Sample samples = 1;
}
```

In the general case, this will allow implementers to have better control over streaming and should allow to achieve better performance at least in some cases (various grpc library implementations have different ways of working with write() syscalls, YMMV).